### PR TITLE
Scene hierarchy tree view example

### DIFF
--- a/Assets/Editor/E07_Data.cs
+++ b/Assets/Editor/E07_Data.cs
@@ -1,0 +1,151 @@
+﻿using UnityEditor;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.Experimental.UIElements;
+using UnityEditor.SceneManagement;
+using UnityEditor.Experimental.UIElements;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UIElementsExamples
+{
+    public class E07_Data : EditorWindow
+    {
+        [MenuItem("UIElementsExamples/07_Data")]
+        public static void ShowExample()
+        {
+            E07_Data window = GetWindow<E07_Data>();
+            window.minSize = new Vector2(450, 200);
+            window.titleContent = new GUIContent("Example 7");
+        }
+
+        static VisualTreeAsset s_Asset;
+        static VisualTreeAsset asset
+        {
+            get
+            {
+                if (s_Asset == null)
+                {
+					s_Asset = Resources.Load<VisualTreeAsset>("TreeView");
+                    Debug.Assert(s_Asset != null);
+                }
+                return s_Asset;
+            }
+        }
+
+        List<int> m_ExpandedGOs;
+
+        public void OnEnable()
+        {
+            if (m_ExpandedGOs == null)
+                m_ExpandedGOs = new List<int>();
+            
+            Scene scene = SceneManager.GetSceneAt(0);
+
+            var scrollView = new ScrollView();
+            scrollView.StretchToParentSize();
+
+            if (scene.IsValid())
+            {
+                GameObject[] gameObjects = scene.GetRootGameObjects();
+                RecursiveSetUp(gameObjects, scrollView.contentView);
+            }
+
+            this.GetRootVisualContainer().AddChild(scrollView);
+            this.GetRootVisualContainer().AddStyleSheetPath("TreeView");
+        }
+
+        static void UpdateName(VisualElement treeViewItem, Object data)
+        {
+            if (data == null)
+                return;
+
+            treeViewItem.Q<Label>().text = data.name;
+        }
+
+        public void UpdateChildren(VisualElement treeViewItem, Object data)
+        {            
+            Transform transform = data as Transform;           
+
+            // Might be deleted
+            if (transform == null)
+                return;
+
+            List<GameObject> gos = new List<GameObject>();
+            for (int i = 0; i < transform.childCount; i++)
+            {
+                gos.Add(transform.GetChild(i).gameObject);
+            }
+            Toggle toggle = treeViewItem.Q<Toggle>();
+			toggle.enabled = gos.Count > 0;
+			toggle.on = toggle.enabled && m_ExpandedGOs.Contains(transform.gameObject.GetInstanceID());
+
+            if (m_ExpandedGOs.Contains(transform.gameObject.GetInstanceID()))
+            {
+                RecursiveSetUp(gos, treeViewItem.Q<VisualContainer>("ChildrenContainer"));    
+            }
+        }
+
+        public void RecursiveSetUp(IEnumerable<GameObject> gameObjects, VisualContainer container)
+        {
+            var currentGOs = new List<GameObject>();
+            container.ToList().ForEach((e) => {
+                GameObject go = e.data as GameObject;
+
+                // remove gone objects
+                if (go == null || !gameObjects.Contains(go))
+                {
+                    container.RemoveChild(e);
+                }
+                // or-remember those that already have an item
+                else
+                {
+                    currentGOs.Add(go);
+                }
+            });
+
+
+            foreach(GameObject go in gameObjects.Except(currentGOs))
+            {
+                VisualContainer added = asset.CloneTree();
+                added.data = go;
+
+                UpdateName(added, go);
+                added.RegisterWatch(go, UpdateName);
+				UpdateChildren(added, go.transform);
+				added.RegisterWatch(go.transform, UpdateChildren);
+				
+				added.Q<Toggle>().OnToggle(() =>
+				{
+                    OnToggle(added);
+				});
+
+                container.AddChild(added);
+			}
+
+            container.Sort((a, b) => {
+                Transform aTrans = (a.data as GameObject).transform;
+                Transform bTrans = (b.data as GameObject).transform;
+                Debug.Assert(aTrans.parent == bTrans.parent);
+				int order = aTrans.GetSiblingIndex() - bTrans.GetSiblingIndex(); 
+                return order;
+            });
+        }
+
+        void OnToggle(VisualContainer treeViewItem)
+        {
+			GameObject go = treeViewItem.data as GameObject;
+            Debug.Assert(go != null, "No GO attached to item!");
+			if (!m_ExpandedGOs.Contains(go.GetInstanceID()))
+            {
+				m_ExpandedGOs.Add(go.GetInstanceID());
+				UpdateChildren(treeViewItem, go.transform);
+            }
+            else
+            {
+                treeViewItem.Q<VisualContainer>("ChildrenContainer").ClearChildren();
+                m_ExpandedGOs.Remove(go.GetInstanceID());
+            }
+        }
+    }
+}

--- a/Assets/Editor/E07_Data.cs.meta
+++ b/Assets/Editor/E07_Data.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 77461745c14624a0f9454aa61255a734
+timeCreated: 1497636521
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Resources/TreeView.uss
+++ b/Assets/Editor/Resources/TreeView.uss
@@ -1,0 +1,32 @@
+#TitleContainer {
+	flex-direction: row;
+}
+
+#ChildrenContainer {
+	padding-left: 20px;
+}
+
+#TitleContainer > Toggle {
+	background-image: resource("Builtin Skins/DarkSkin/Images/IN foldout.png");
+}
+
+#TitleContainer > Toggle:focus, #TitleContainer Toggle:focus:active {
+	background-image: resource("Builtin Skins/DarkSkin/Images/IN foldout focus.png");
+}
+
+#TitleContainer > Toggle:active {
+	background-image: resource("Builtin Skins/DarkSkin/Images/IN foldout act.png");
+}
+
+#TitleContainer > Toggle:checked {
+	background-image: resource("Builtin Skins/DarkSkin/Images/IN foldout on.png");
+}
+
+#TitleContainer > Toggle:checked:focus {
+	background-image: resource("Builtin Skins/DarkSkin/Images/IN foldout focus on.png");
+}
+
+#TitleContainer > Toggle:checked:active:focus, #TitleContainer > Toggle:checked:active {
+	background-image: resource("Builtin Skins/DarkSkin/Images/IN foldout act on.png");
+}
+

--- a/Assets/Editor/Resources/TreeView.uss.meta
+++ b/Assets/Editor/Resources/TreeView.uss.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 6a74ec9861ea84a0e8d9c0b18aa698d3
+timeCreated: 1497643291
+licenseType: Pro
+ScriptedImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/Editor/Resources/TreeView.uxml
+++ b/Assets/Editor/Resources/TreeView.uxml
@@ -1,0 +1,9 @@
+<Template id="TreeView" xmlns="UnityEngine.Experimental.UIElements">
+	<VisualContainer class="TreeView">
+		<VisualContainer name="TitleContainer">
+			<Toggle />
+			<Label text="Hello" />
+		</VisualContainer>
+		<VisualContainer name="ChildrenContainer" />
+	</VisualContainer>
+</Template>

--- a/Assets/Editor/Resources/TreeView.uxml.meta
+++ b/Assets/Editor/Resources/TreeView.uxml.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f05a1e0d273c94b1db91b227901e714f
+timeCreated: 1497641174
+licenseType: Pro
+ScriptedImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {instanceID: 0}

--- a/Assets/Editor/Resources/uielementssettings.asset
+++ b/Assets/Editor/Resources/uielementssettings.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 1
+  m_Script: {fileID: 11995, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: uielementssettings
+  m_EditorClassIdentifier: 
+  viewTable:
+  - id: TreeView
+    viewNamespace: 
+    template: {fileID: 11400000, guid: f05a1e0d273c94b1db91b227901e714f, type: 3}

--- a/Assets/Editor/Resources/uielementssettings.asset.meta
+++ b/Assets/Editor/Resources/uielementssettings.asset.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a81d4a7a8aa0b42de8dd71487a71547c
+timeCreated: 1497641183
+licenseType: Pro
+NativeFormatImporter:
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/test.unity.meta
+++ b/Assets/test.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4bec13b6b59034d489d25bc50298fe72
+timeCreated: 1497648683
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.2.0a1
+m_EditorVersion: 2017.2.0a4


### PR DESCRIPTION
Simple example of custom tree view for the scene hierarchy.
It uses UXML draft implementation in conjunction with UQuery.
Also benefits from some adjustments of DataWatch which is now available in all contexts.